### PR TITLE
Update ADAM dependency version to 0.27.0

### DIFF
--- a/deca-cli/pom.xml
+++ b/deca-cli/pom.xml
@@ -19,6 +19,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.bdgenomics.adam</groupId>
+            <artifactId>adam-shade-spark2_${scala.version.prefix}</artifactId>
+            <version>${adam.version}</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
           <filters>
@@ -39,8 +46,9 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <shaderHint>workaround</shaderHint>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
               </transformers>
             </configuration>
           </execution>

--- a/deca-cli/src/main/scala/org/bdgenomics/deca/cli/CNVer.scala
+++ b/deca-cli/src/main/scala/org/bdgenomics/deca/cli/CNVer.scala
@@ -103,26 +103,26 @@ class CNVer(protected val args: CNVerArgs) extends BDGSparkCommand[CNVerArgs] {
         ARF.duplicateRead,
         ARF.failedVendorQualityChecks,
         ARF.primaryAlignment,
-        ARF.mapq,
-        ARF.contigName,
+        ARF.mappingQuality,
+        ARF.referenceName,
         ARF.start,
         ARF.end,
         ARF.cigar,
         ARF.mateMapped,
-        ARF.mateContigName,
+        ARF.mateReferenceName,
         ARF.mateAlignmentStart,
-        ARF.inferredInsertSize)
+        ARF.insertSize)
       Projection(readFields: _*)
     }
 
     val readsRdds = args.readsPaths.map(path => {
       // TODO: Add push down filters
-      log.info("Loading {} alignment file", path)
+      info("Loading %s alignment file".format(path))
       sc.loadAlignments(path, optProjection = Some(readProj), stringency = ValidationStringency.SILENT)
     })
 
     val targetsAsFeatures = {
-      val targetProj = Projection(FF.contigName, FF.start, FF.end)
+      val targetProj = Projection(FF.referenceName, FF.start, FF.end)
       sc.loadFeatures(args.targetsPath, optProjection = Some(targetProj))
     }
 

--- a/deca-cli/src/main/scala/org/bdgenomics/deca/cli/Coverager.scala
+++ b/deca-cli/src/main/scala/org/bdgenomics/deca/cli/Coverager.scala
@@ -88,25 +88,25 @@ class Coverager(protected val args: CoveragerArgs) extends BDGSparkCommand[Cover
         ARF.duplicateRead,
         ARF.failedVendorQualityChecks,
         ARF.primaryAlignment,
-        ARF.mapq,
-        ARF.contigName,
+        ARF.mappingQuality,
+        ARF.referenceName,
         ARF.start,
         ARF.end,
         ARF.cigar,
         ARF.mateMapped,
-        ARF.mateContigName,
+        ARF.mateReferenceName,
         ARF.mateAlignmentStart,
-        ARF.inferredInsertSize)
+        ARF.insertSize)
       Projection(readFields: _*)
     }
 
     val readsRdds = args.readsPaths.map(path => {
       // TODO: Add push down filters
-      log.info("Loading {} alignment file", path)
+      info("Loading %s alignment file".format(path))
       sc.loadAlignments(path, optProjection = Some(readProj), stringency = ValidationStringency.SILENT)
     })
 
-    val targetProj = Projection(FF.contigName, FF.start, FF.end)
+    val targetProj = Projection(FF.referenceName, FF.start, FF.end)
     val targetsAsFeatures = sc.loadFeatures(args.targetsPath, optProjection = Some(targetProj))
 
     var matrix = Coverage.coverageMatrix(readsRdds, targetsAsFeatures, minMapQ = args.minMappingQuality)

--- a/deca-core/src/test/scala/org/bdgenomics/deca/HMMSuite.scala
+++ b/deca-core/src/test/scala/org/bdgenomics/deca/HMMSuite.scala
@@ -81,7 +81,7 @@ class HMMSuite extends DecaFunSuite {
 
     val del = cnvs.rdd.filter(f => Option(f.getSource).exists(_.equals("HG00121"))).first()
     assert(del.getFeatureType() == "DEL")
-    assert(del.getContigName() == "22")
+    assert(del.getReferenceName() == "22")
     assert(del.getStart() == 18898401L)
     assert(del.getEnd() == 18913235L)
     assert(aboutEq(del.getScore(), 9.167934190998345))
@@ -95,7 +95,7 @@ class HMMSuite extends DecaFunSuite {
 
     val dup = cnvs.rdd.filter(f => Option(f.getSource).exists(_.equals("HG00113"))).first()
     assert(dup.getFeatureType() == "DUP")
-    assert(dup.getContigName() == "22")
+    assert(dup.getReferenceName() == "22")
     assert(dup.getStart() == 17071767L)
     assert(dup.getEnd() == 17073440L)
     assert(aboutEq(dup.getScore(), 25.321428730083596))

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   
   <properties>
     <java.version>1.8</java.version>
-    <adam.version>0.27.0-SNAPSHOT</adam.version>
+    <adam.version>0.27.0</adam.version>
     <avro.version>1.8.2</avro.version>
     <scala.version>2.11.12</scala.version>
     <scala.version.prefix>2.11</scala.version.prefix>

--- a/pom.xml
+++ b/pom.xml
@@ -16,15 +16,15 @@
   
   <properties>
     <java.version>1.8</java.version>
-    <adam.version>0.24.0</adam.version>
-    <avro.version>1.8.0</avro.version>
-    <scala.version>2.11.8</scala.version>
+    <adam.version>0.27.0-SNAPSHOT</adam.version>
+    <avro.version>1.8.2</avro.version>
+    <scala.version>2.11.12</scala.version>
     <scala.version.prefix>2.11</scala.version.prefix>
-    <spark.version>2.1.0</spark.version>
+    <spark.version>2.4.3</spark.version>
     <breeze.version>0.12</breeze.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.7.3</hadoop.version>
-    <utils.version>0.2.13</utils.version>
+    <utils.version>0.2.15</utils.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
   </properties>
   
@@ -87,12 +87,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.4.1</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>2.4.3</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -102,7 +102,7 @@
         <plugin>
           <groupId>pl.project13.maven</groupId>
           <artifactId>git-commit-id-plugin</artifactId>
-          <version>2.2.1</version>
+          <version>2.2.2</version>
           <configuration>
             <gitDescribe>
               <always>true</always>
@@ -138,7 +138,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.8.0</version>
           <configuration>
             <source>${java.version}</source>
             <target>${java.version}</target>
@@ -149,17 +149,67 @@
           <artifactId>scala-maven-plugin</artifactId>
           <version>3.2.2</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.0.0-M1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.6</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.0.0-M1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.1.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+          <configuration>
+            <mavenExecutorId>forked-path</mavenExecutorId>
+            <useReleaseProfile>false</useReleaseProfile>
+            <arguments>-Psonatype-oss-release</arguments>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.0.1</version>
+        </plugin>
         <!-- disable surefire -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.7</version>
+          <version>3.0.0-M3</version>
         </plugin>
         <!-- enable scalatest -->
         <plugin>
           <groupId>org.scalatest</groupId>
           <artifactId>scalatest-maven-plugin</artifactId>
-          <version>1.0</version>
+          <version>2.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.scalariform</groupId>
@@ -169,7 +219,7 @@
         <plugin>
           <artifactId>exec-maven-plugin</artifactId>
           <groupId>org.codehaus.mojo</groupId>
-          <version>1.3.2</version>
+          <version>1.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -264,7 +314,6 @@
       <plugin>
         <groupId>org.scalariform</groupId>
         <artifactId>scalariform-maven-plugin</artifactId>
-        <version>0.1.4</version>
         <executions>
           <execution>
             <id>default-cli</id>
@@ -282,6 +331,7 @@
     </plugins>
   </build>
 
+  <!--
   <repositories>
     <repository>
       <id>Sonatype</id>
@@ -292,6 +342,7 @@
       <url>http://people.apache.org/repo/m2-snapshot-repository</url>
     </repository>
   </repositories>
+  -->
 
   <dependencyManagement>
     <dependencies>
@@ -379,7 +430,7 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.version.prefix}</artifactId>
-        <version>2.2.6</version>
+        <version>3.0.7</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -390,12 +441,12 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.4</version>
+        <version>2.6</version>
       </dependency>
       <dependency>
         <groupId>args4j</groupId>
         <artifactId>args4j</artifactId>
-        <version>2.0.31</version> <!-- note: version 2.32 is not binary compatible -->
+        <version>2.33</version>
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
@@ -436,7 +487,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.0.1</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -450,7 +500,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.10.4</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -505,7 +554,7 @@
             <artifactId>scoverage-maven-plugin</artifactId>
             <version>${scoverage.plugin.version}</version>
             <configuration>
-              <scalaVersion>2.11.4</scalaVersion>
+              <scalaVersion>${scala.version}</scalaVersion>
               <excludedPackages>org.bdgenomics.deca.Timers</excludedPackages>
               <aggregate>true</aggregate>
               <minimumCoverage>90</minimumCoverage>
@@ -522,7 +571,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
Fixes #34 

Updates ADAM dependency version to 0.27.0.  Note the workaround in `maven-shade-plugin` configuration to prevent runtime conflicts with parquet and avro versions.